### PR TITLE
Add query related components

### DIFF
--- a/src/components/query/display.js
+++ b/src/components/query/display.js
@@ -1,0 +1,57 @@
+import { PanelBody, RangeControl, SelectControl } from "@wordpress/components";
+import { __ } from "@wordpress/i18n";
+
+/**
+ * Render the settings block used to select the post types.
+ *
+ * @since 0.1.0
+ *
+ * @returns {WPElement} Element to render.
+ */
+function QueryDisplay(props) {
+	const {
+		attributes: { postsPerPage, columnCount, displayAs },
+		setAttributes,
+	} = props;
+
+	return (
+		<PanelBody
+			title={__("Display Options", "built_starter")}
+			initialOpen={true}
+		>
+			<SelectControl
+				label="Display As"
+				value={displayAs}
+				options={[
+					{ label: "Grid", value: "grid" },
+					{ label: "Slider", value: "slider" },
+				]}
+				onChange={(value) => setAttributes({ displayAs: value })}
+			/>
+
+			<RangeControl
+				label="Amount to Display"
+				value={postsPerPage}
+				onChange={(postsPerPageNew) =>
+					setAttributes({ postsPerPage: postsPerPageNew })
+				}
+				min={1}
+				max={12}
+			/>
+
+			<RangeControl
+				label={
+					displayAs == "grid" ? __("Columns") : __("Slides to Show")
+				}
+				value={columnCount}
+				onChange={(columnCountNew) =>
+					setAttributes({ columnCount: columnCountNew })
+				}
+				min={1}
+				max={4}
+			/>
+		</PanelBody>
+	);
+}
+
+export { QueryDisplay };

--- a/src/components/query/order.js
+++ b/src/components/query/order.js
@@ -1,0 +1,47 @@
+import { PanelBody, SelectControl } from "@wordpress/components";
+import { __ } from "@wordpress/i18n";
+
+/**
+ * Render the settings block used to select the post types.
+ *
+ * @since 0.1.0
+ *
+ * @returns {WPElement} Element to render.
+ */
+function QueryOrder(props) {
+	const {
+		attributes: { orderPostsBy, orderPostsDirection },
+		setAttributes,
+	} = props;
+
+	return (
+		<PanelBody title={__("Order", "built_starter")} initialOpen={true}>
+			<SelectControl
+				label="Order By"
+				value={orderPostsBy}
+				options={[
+					{ label: "Custom Order", value: "menu_order" },
+					{ label: "Date", value: "date" },
+					{ label: "Title", value: "title" },
+				]}
+				onChange={(value) => setAttributes({ orderPostsBy: value })}
+				__nextHasNoMarginBottom
+			/>
+
+			<SelectControl
+				label="Order Direction"
+				value={orderPostsDirection}
+				options={[
+					{ label: "Ascending", value: "asc" },
+					{ label: "Descending", value: "desc" },
+				]}
+				onChange={(value) =>
+					setAttributes({ orderPostsDirection: value })
+				}
+				__nextHasNoMarginBottom
+			/>
+		</PanelBody>
+	);
+}
+
+export { QueryOrder };

--- a/src/components/query/pagination.js
+++ b/src/components/query/pagination.js
@@ -5,7 +5,7 @@
  *
  * @returns {WPElement} Element to render.
  */
-function Pagination() {
+function QueryPagination() {
 	return (
 		<div className="pagination" aria-label="Navigate Between Archive Pages">
 			<ul className="page-numbers">
@@ -27,4 +27,4 @@ function Pagination() {
 	);
 }
 
-export { Pagination };
+export { QueryPagination };

--- a/src/components/query/selectPostType.js
+++ b/src/components/query/selectPostType.js
@@ -1,0 +1,55 @@
+import { PanelBody, SelectControl } from "@wordpress/components";
+import { useSelect } from "@wordpress/data";
+import { __ } from "@wordpress/i18n";
+
+/**
+ * Render the settings block used to select the post types.
+ *
+ * @since 0.1.0
+ *
+ * @returns {WPElement} Element to render.
+ */
+function QuerySelectPostType(props) {
+	const {
+		attributes: { selectedPostType },
+		setAttributes,
+	} = props;
+
+	const getPostTypesOptions = () => {
+		const getPostTypeList = useSelect((select) =>
+			select("core").getPostTypes({ per_page: 20 }),
+		);
+		let filteredPostTypes = [];
+		let postTypesOptions = [];
+
+		if (getPostTypeList) {
+			filteredPostTypes = getPostTypeList.filter(
+				(postType) =>
+					postType.viewable == true &&
+					postType.rest_base !== "media" &&
+					postType.rest_base !== "pages",
+				//postType.rest_base == 'posts' ||
+				//postType.rest_base == 'built_promotion'
+			);
+			postTypesOptions = filteredPostTypes.map((postType) => ({
+				label: postType.name,
+				value: postType.slug,
+			}));
+		}
+
+		return postTypesOptions;
+	};
+
+	return (
+		<PanelBody>
+			<SelectControl
+				label={__("Select Post Type", "built_starter")}
+				onChange={(value) => setAttributes({ selectedPostType: value })}
+				options={getPostTypesOptions()}
+				value={selectedPostType}
+			/>
+		</PanelBody>
+	);
+}
+
+export { QuerySelectPostType };

--- a/src/components/query/taxonomy.js
+++ b/src/components/query/taxonomy.js
@@ -1,0 +1,87 @@
+import {
+	FormTokenField,
+	PanelBody,
+	SelectControl,
+} from "@wordpress/components";
+import { useSelect } from "@wordpress/data";
+import { __ } from "@wordpress/i18n";
+
+function QueryTaxonomy(props) {
+	const {
+		attributes: { selectedTaxonomy, selectedTerms },
+		setAttributes,
+		postType,
+	} = props;
+
+	const taxonomies = useSelect((select) =>
+		select("core").getTaxonomies({ per_page: -1 }),
+	);
+
+	const filteredTaxonomies = taxonomies
+		? taxonomies.filter((tax) => tax.types.includes(postType))
+		: [];
+
+	const taxonomyOptions = filteredTaxonomies.map((tax) => ({
+		label: tax.labels.singular_name || tax.name,
+		value: tax.slug,
+	}));
+
+	const terms = useSelect((select) =>
+		selectedTaxonomy
+			? select("core").getEntityRecords("taxonomy", selectedTaxonomy, {
+					per_page: -1,
+				})
+			: [],
+	);
+
+	const termOptions = terms
+		? terms.map((term) => ({
+				label: term.name,
+				value: term.id.toString(), // Convert id to string
+			}))
+		: [];
+
+	return (
+		<PanelBody title={__("Taxonomy Filter", "built")} initialOpen={false}>
+			<SelectControl
+				label={__("Select Taxonomy", "built")}
+				value={selectedTaxonomy}
+				options={[
+					{ label: __("None", "built"), value: "" },
+					...taxonomyOptions,
+				]}
+				onChange={(value) =>
+					setAttributes({
+						selectedTaxonomy: value,
+						selectedTerms: [],
+					})
+				}
+			/>
+			{selectedTaxonomy && (
+				<FormTokenField
+					label={__("Select Terms", "built")}
+					value={selectedTerms.map((termId) => {
+						const term = termOptions.find(
+							(t) => t.value === termId.toString(),
+						);
+						return term ? term.label : "";
+					})}
+					suggestions={termOptions.map((option) => option.label)}
+					onChange={(termNames) => {
+						const newSelectedTerms = termNames
+							.map((name) => {
+								const term = termOptions.find(
+									(t) => t.label === name,
+								);
+								return term ? term.value : null;
+							})
+							.filter((id) => id !== null);
+						setAttributes({ selectedTerms: newSelectedTerms });
+					}}
+				/>
+			)}
+		</PanelBody>
+	);
+}
+
+export { QueryTaxonomy };

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,21 @@
 /* Components */
 export { AttachmentImage } from "./components/attachment-image";
 export {
-    CustomBlockAppender,
-    CustomInspectorAppender,
+	CustomBlockAppender,
+	CustomInspectorAppender,
 } from "./components/block-appender";
 export {
-    EditorMediaUpload,
-    InspectorMediaUpload,
-    ToolbarMediaUpload,
+	EditorMediaUpload,
+	InspectorMediaUpload,
+	ToolbarMediaUpload,
 } from "./components/media-upload";
-export { Pagination } from "./components/pagination";
+export { QueryDisplay } from "./components/query/display";
+export { QueryOrder } from "./components/query/order";
+export { QueryPagination } from "./components/query/pagination";
+export { QuerySelectPostType } from "./components/query/selectPostType";
+export { QueryTaxonomy } from "./components/query/taxonomy";
 export {
-    SectionBackground,
-    SectionSettings,
-    SectionWrapper,
+	SectionBackground,
+	SectionSettings,
+	SectionWrapper,
 } from "./components/section-settings";


### PR DESCRIPTION
The following post type query components have been added:

- Pagination: shows pagination controls.
- Select Post Type: select field to choose post type.
- Order: controls for order by and order direction.
- Taxonmy: filtering for taxonomies.
- Display: select field to select from grid or slider.